### PR TITLE
Bolt file location change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # telemetry_collector
-Automatically build telemetry collector with [Telegraf](https://github.com/influxdata/telegraf), [Influxdb](https://github.com/influxdata/influxdb), and [Grafana](https://github.com/grafana/grafana), the example of sensor paths is using the native yang model and OpenConfig yang model of NX-OS as an example. `build.sh` script will create self-signed certificates for TLS transport. Using docker images of Telegraf, Influxdb, and Grafana to create containers with docker-compose. tested with `telegraf >= 1.12.1`, `influxdb >= 2.0` and `grafana>=8.1`.
+Automatically build telemetry collector with [Telegraf](https://github.com/influxdata/telegraf), [Influxdb](https://github.com/influxdata/influxdb), and [Grafana](https://github.com/grafana/grafana), the example of sensor paths is using the native yang model and OpenConfig yang model of NX-OS as an example. `build.sh` script will create self-signed certificates for TLS transport. Using docker images of Telegraf, Influxdb, and Grafana to create containers with docker-compose. tested with `telegraf >= 1.34.2`, `influxdb >= 2.7.12` and `grafana>=11.6.0`.
 
 # NOTE:
 This project has upgraded the Influxdb to 2.0 which is not supported by Chronograf anymore, the dashboard is changed to Grafana with a new set of sensor paths. original code is moved to branch [chronograf_influxdb_1_x](https://github.com/dsx1123/telemetry_collector/tree/chronograf_influxdb_1_x)
@@ -50,7 +50,7 @@ docker-ce, OpenSSL, docker-compose, any Linux distribution, see Known Issues if 
 
     ```
 
-3. TLS need to be enabled for the gNMI plugin as well as nx-os, when configuring feature gRPC on a switch, a default certificate with 1-day validation is auto-generated, to configure the certificate for gRPC on nx-os, copy `etc/telegraf/cert/gnmi.pfx` to bootflash, then use below commands to import the certificate, the `<export password>` is set to `cisco123` by default, you could modify it in `build.sh`, these steps are optional as the gnmi plugin in telegraf is set to disable certificate verification. 
+3. TLS need to be enabled for the gNMI plugin as well as nx-os, when configuring feature gRPC on a switch, a default certificate with 1-day validation is auto-generated, to configure the certificate for gRPC on nx-os, copy `etc/telegraf/cert/gnmi.pfx` to bootflash, then use below commands to import the certificate, the `<export password>` is set to `cisco123` by default, you could modify it in `build.sh`, these steps are optional as the gnmi plugin in telegraf is set to disable certificate verification.
     ```
     switch(config)# crypto ca trustpoint gnmi_trustpoint
     switch(config-trustpoint)# crypto ca import gnmi_trustpoint pkcs12 bootflash:gnmi.pfx <export password>

--- a/build.sh
+++ b/build.sh
@@ -8,9 +8,9 @@ export INFLUXDB_ENGINE="`pwd`/influxdb"
 export CURRENT_UID=`id -u`
 export CURRENT_GID=`id -g`
 
-export TELEGRAF_IMAGE="telegraf:1.29.2"
-export INFLUXDB_IMAGE="influxdb:2.7.1"
-export GRAFANA_IMAGE="grafana/grafana:10.2.0"
+export TELEGRAF_IMAGE="telegraf:1.34.2"
+export INFLUXDB_IMAGE="influxdb:2.7.12"
+export GRAFANA_IMAGE="grafana/grafana:11.6.0"
 
 export INFLUXDB_USER="influxdb"
 export INFLUXDB_PASSWD="cisco123"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - INFLUXD_CONFIG_PATH=/etc/influxdb
       - INFLUXD_ENGINE_PATH=/var/lib/influxdb2/engine
+      - INFLUXD_BOLT_PATH=/var/lib/influxdb2/influxd.bolt
 
   telegraf:
     image: ${TELEGRAF_IMAGE}  #telegraf

--- a/etc/telegraf/telegraf.d/gnmi.conf.example
+++ b/etc/telegraf/telegraf.d/gnmi.conf.example
@@ -7,7 +7,7 @@ username = "cisco"
 password = "cisco"
 
 ### enable client-side TLS and define CA to authenticate the device
-enable_tls = true
+tls_enable = true
 tls_ca = "/etc/telegraf/cert/gnmi.crt"
 # set insecure_skip_verify to false to enable server certificate verification
 insecure_skip_verify = true


### PR DESCRIPTION
The bolt file needs to be in a persistent location. Otherwise updating influxdb or recreating the container will cause a loss of all existing data when the influxdb container is destroyed taking the bolt file with it.